### PR TITLE
ci: fix pnpm version mismatch causing CI failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,6 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v6
-        with:
-          version: 10.33.0
 
       - uses: actions/setup-node@v6
         with:
@@ -56,8 +54,6 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v6
-        with:
-          version: 10.33.0
 
       - uses: actions/setup-node@v6
         with:
@@ -77,8 +73,6 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v6
-        with:
-          version: 10.33.0
 
       - uses: actions/setup-node@v6
         with:
@@ -102,8 +96,6 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v6
-        with:
-          version: 10.33.0
 
       - uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
## Summary

- Removes hardcoded `version: 10.33.0` from all `pnpm/action-setup@v6` steps in `.github/workflows/ci.yml`
- The workflow was pinned to pnpm 10.33.0 while `package.json` declares `pnpm@11.0.9` via the `packageManager` field, causing the action to error with "Multiple versions of pnpm specified"
- With no explicit version, `pnpm/action-setup@v6` automatically reads the version from `packageManager` in `package.json`, eliminating the conflict

## Test plan

- [ ] Verify CI passes after merge (all three failing jobs: Lint & format, Test, Type check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)