### PR TITLE
feat(api): extend search to cover title and description fields

### DIFF
--- a/apps/api/src/routes/urls.ts
+++ b/apps/api/src/routes/urls.ts
@@ -38,7 +38,7 @@ export async function urlRoutes(fastify: FastifyInstance) {
             },
             q: {
               type: 'string',
-              description: 'Search query — filters by slug, title, or original URL',
+              description: 'Search query — filters by slug, title, description, or original URL',
             },
           },
         },

--- a/apps/api/src/services/url.service.ts
+++ b/apps/api/src/services/url.service.ts
@@ -291,7 +291,12 @@ export async function deleteUrls(slugs: string[]): Promise<{ deleted: number }> 
 export async function getUrlList(page: number, perPage: number, offset: number, q?: string) {
   const escaped = q ? q.replace(/[%_\\]/g, '\\$&') : undefined
   const filter = escaped
-    ? or(ilike(urls.slug, `%${escaped}%`), ilike(urls.originalUrl, `%${escaped}%`))
+    ? or(
+        ilike(urls.slug, `%${escaped}%`),
+        ilike(urls.originalUrl, `%${escaped}%`),
+        ilike(urls.title, `%${escaped}%`),
+        ilike(urls.description, `%${escaped}%`),
+      )
     : undefined
 
   const [rows, countResult] = await Promise.all([


### PR DESCRIPTION
## Summary
`getUrlList`'s search filter only matched `slug` and `originalUrl` via `ILIKE`. Extends it to also match `title` and `description` — the existing wildcard-escaping already handles sanitization for all four columns.

Bonus: the route's OpenAPI doc string already (incorrectly) claimed search covered `title` — this change makes that true, and I updated the string to mention `description` too.

## Testing
- `pnpm --filter api run typecheck` ✅
- `pnpm --filter api run lint` ✅
- `pnpm --filter api run test` — 214/214 passing ✅

No new test added: this is a 4-line extension of an existing `or(ilike(...))` filter using the exact same pattern already exercised by `getUrlList`'s existing search/escaping tests, and the mocked DB layer can't meaningfully assert *which* columns a drizzle expression targets without inspecting query internals — not worth the brittleness for this diff.

Closes #159