### PR TITLE
refactor(api): run getUrlStats' independent click queries in parallel

### DIFF
--- a/apps/api/src/services/url.service.ts
+++ b/apps/api/src/services/url.service.ts
@@ -217,42 +217,43 @@ export async function getUrlStats(slug: string, baseUrl: string): Promise<UrlSta
   const ago7d = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000)
   const ago30d = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000)
 
-  const [clickStats] = await db
-    .select({
-      total: count(),
-      last24h: sql<number>`count(*) filter (where ${clicks.clickedAt} >= ${ago24h})`,
-      last7d: sql<number>`count(*) filter (where ${clicks.clickedAt} >= ${ago7d})`,
-    })
-    .from(clicks)
-    .where(eq(clicks.urlId, url.id))
-
-  const recentClicks = await db.query.clicks.findMany({
-    where: eq(clicks.urlId, url.id),
-    orderBy: (clicks, { desc }) => [desc(clicks.clickedAt)],
-    limit: 10,
-  })
-
-  const clicksByDay = await db
-    .select({
-      date: sql<string>`date_trunc('day', ${clicks.clickedAt})::date::text`,
-      count: count(),
-    })
-    .from(clicks)
-    .where(and(eq(clicks.urlId, url.id), gte(clicks.clickedAt, ago30d)))
-    .groupBy(sql`date_trunc('day', ${clicks.clickedAt})`)
-    .orderBy(sql`date_trunc('day', ${clicks.clickedAt})`)
-
   // Extract hostname via split_part to avoid backslash escape issues in tagged template literals.
   // split_part(referer, '://', 2) → 'host/path', split_part(..., '/', 1) → 'host'
   const refDomain = sql<string>`case when ${clicks.referer} is null or ${clicks.referer} = '' then 'Direct' when ${clicks.referer} ~ '^https?://' then lower(split_part(split_part(${clicks.referer}, '://', 2), '/', 1)) else 'Direct' end`
 
-  const referrers = await db
-    .select({ domain: refDomain, count: count() })
-    .from(clicks)
-    .where(eq(clicks.urlId, url.id))
-    .groupBy(refDomain)
-    .orderBy(sql`count(*) desc`)
-    .limit(10)
+  // These four queries are independent reads over the same clicks rows — fire them as one
+  // round trip instead of awaiting each in turn.
+  const [[clickStats], recentClicks, clicksByDay, referrers] = await Promise.all([
+    db
+      .select({
+        total: count(),
+        last24h: sql<number>`count(*) filter (where ${clicks.clickedAt} >= ${ago24h})`,
+        last7d: sql<number>`count(*) filter (where ${clicks.clickedAt} >= ${ago7d})`,
+      })
+      .from(clicks)
+      .where(eq(clicks.urlId, url.id)),
+    db.query.clicks.findMany({
+      where: eq(clicks.urlId, url.id),
+      orderBy: (clicks, { desc }) => [desc(clicks.clickedAt)],
+      limit: 10,
+    }),
+    db
+      .select({
+        date: sql<string>`date_trunc('day', ${clicks.clickedAt})::date::text`,
+        count: count(),
+      })
+      .from(clicks)
+      .where(and(eq(clicks.urlId, url.id), gte(clicks.clickedAt, ago30d)))
+      .groupBy(sql`date_trunc('day', ${clicks.clickedAt})`)
+      .orderBy(sql`date_trunc('day', ${clicks.clickedAt})`),
+    db
+      .select({ domain: refDomain, count: count() })
+      .from(clicks)
+      .where(eq(clicks.urlId, url.id))
+      .groupBy(refDomain)
+      .orderBy(sql`count(*) desc`)
+      .limit(10),
+  ])
 
   const dayMap = new Map<string, number>()
   for (let i = 29; i >= 0; i--) {


### PR DESCRIPTION
## Summary
`getUrlStats` still had 4 sequential DB round-trips after `findUrlBySlug`: `clickStats`, `recentClicks`, `clicksByDay`, `referrers`. PR #41 (closing #38) only merged the three count queries into one `clickStats` query — it didn't touch the other three, which remained separate `await`s in series.

They're all independent reads over the same `clicks` rows for the same `url.id`, so there's no reason to serialize them. This wraps them in `Promise.all`, cutting stats-page latency from ~4 round trips to 1 concurrent batch (plus the initial `findUrlBySlug`).

Didn't collapse it into a single raw SQL query (CTEs + `json_agg`) — that trades a straightforward, type-safe Drizzle query builder for hand-written SQL to shave one more round-trip off an already-parallelized read. Not worth it unless stats-page latency is still a measured problem after this.

## Testing
- `pnpm --filter api run typecheck` ✅
- `pnpm --filter api run lint` ✅
- `pnpm --filter api run test` — 214/214 passing, no test changes needed (mock call order is unaffected since `Promise.all([a, b, c, d])` still invokes each query builder synchronously in the same left-to-right order the sequential `await`s did)

Closes #172