### PR TITLE
test(web): add component tests for Table, UrlsView, ConfirmDialog, Pagination

### DIFF
--- a/apps/web/src/components/UrlsView/Pagination.test.tsx
+++ b/apps/web/src/components/UrlsView/Pagination.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/react'
+import { ThemeProvider } from 'styled-components'
+import { describe, expect, it } from 'vitest'
+import { theme } from '@/lib/theme'
+import { Pagination } from './Pagination'
+
+function renderPagination(props: React.ComponentProps<typeof Pagination>) {
+  return render(
+    <ThemeProvider theme={theme}>
+      <Pagination {...props} />
+    </ThemeProvider>,
+  )
+}
+
+describe('Pagination', () => {
+  it('shows the result range and current page', () => {
+    renderPagination({ page: 2, perPage: 10, total: 25, totalPages: 3 })
+    expect(screen.getByText('11–20 of 25 URLs')).toBeInTheDocument()
+    expect(screen.getByText('Page 2')).toBeInTheDocument()
+  })
+
+  it('caps the upper limit at the total on the last page', () => {
+    renderPagination({ page: 3, perPage: 10, total: 25, totalPages: 3 })
+    expect(screen.getByText('21–25 of 25 URLs')).toBeInTheDocument()
+  })
+
+  it('disables Prev on the first page', () => {
+    renderPagination({ page: 1, perPage: 10, total: 25, totalPages: 3 })
+    expect(screen.getByRole('button', { name: 'Previous page' })).toBeDisabled()
+    expect(screen.getByRole('link', { name: 'Next page' })).toHaveAttribute(
+      'href',
+      '?page=2&perPage=10',
+    )
+  })
+
+  it('disables Next on the last page', () => {
+    renderPagination({ page: 3, perPage: 10, total: 25, totalPages: 3 })
+    expect(screen.getByRole('button', { name: 'Next page' })).toBeDisabled()
+    expect(screen.getByRole('link', { name: 'Previous page' })).toHaveAttribute(
+      'href',
+      '?page=2&perPage=10',
+    )
+  })
+
+  it('builds Prev/Next hrefs that preserve the search query', () => {
+    renderPagination({ page: 2, perPage: 10, total: 25, totalPages: 3, q: 'foo bar' })
+    expect(screen.getByRole('link', { name: 'Previous page' })).toHaveAttribute(
+      'href',
+      '?page=1&perPage=10&q=foo+bar',
+    )
+    expect(screen.getByRole('link', { name: 'Next page' })).toHaveAttribute(
+      'href',
+      '?page=3&perPage=10&q=foo+bar',
+    )
+  })
+
+  it('enables both Prev and Next on a middle page', () => {
+    renderPagination({ page: 2, perPage: 10, total: 25, totalPages: 3 })
+    expect(screen.getByRole('link', { name: 'Previous page' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Next page' })).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/UrlsView/Table.test.tsx
+++ b/apps/web/src/components/UrlsView/Table.test.tsx
@@ -1,0 +1,143 @@
+// @vitest-environment jsdom
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ThemeProvider } from 'styled-components'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { UrlListRecord } from '@snip/types'
+import { theme } from '@/lib/theme'
+import { ToastProvider } from '@/components/Toast'
+import { Table } from './Table'
+
+const mockRefresh = vi.fn()
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ refresh: mockRefresh }),
+}))
+
+vi.mock('@/lib/api', () => ({
+  api: { deleteUrl: vi.fn(), deleteUrls: vi.fn() },
+}))
+
+import { api } from '@/lib/api'
+
+const mockDeleteUrl = vi.mocked(api.deleteUrl)
+const mockDeleteUrls = vi.mocked(api.deleteUrls)
+
+function makeUrl(overrides: Partial<UrlListRecord> = {}): UrlListRecord {
+  return {
+    id: overrides.id ?? 'uuid-1',
+    slug: overrides.slug ?? 'abc123',
+    originalUrl: overrides.originalUrl ?? 'https://example.com',
+    shortUrl: overrides.shortUrl ?? 'http://localhost:3001/abc123',
+    customSlug: overrides.customSlug ?? false,
+    title: overrides.title ?? null,
+    description: overrides.description ?? null,
+    expiresAt: overrides.expiresAt ?? null,
+    createdAt: overrides.createdAt ?? '2024-01-01T00:00:00.000Z',
+  }
+}
+
+function renderTable(data: UrlListRecord[]) {
+  return render(
+    <ThemeProvider theme={theme}>
+      <ToastProvider>
+        <Table data={data} />
+      </ToastProvider>
+    </ThemeProvider>,
+  )
+}
+
+beforeEach(() => {
+  mockRefresh.mockClear()
+  mockDeleteUrl.mockReset()
+  mockDeleteUrls.mockReset()
+})
+
+describe('Table', () => {
+  it('renders a card per URL with its short and destination links', () => {
+    renderTable([makeUrl({ slug: 'foo', shortUrl: 'http://localhost:3001/foo' })])
+    expect(
+      screen.getByRole('link', { name: /open http:\/\/localhost:3001\/foo/i }),
+    ).toHaveAttribute('href', 'http://localhost:3001/foo')
+    expect(screen.getByText('https://example.com')).toBeInTheDocument()
+  })
+
+  it('shows an expired badge for a URL past its expiry', () => {
+    const expiresAt = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString()
+    renderTable([makeUrl({ expiresAt })])
+    expect(screen.getByText('expired')).toBeInTheDocument()
+  })
+
+  it('shows an expiring-soon badge for a URL expiring within 7 days', () => {
+    const expiresAt = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000).toISOString()
+    renderTable([makeUrl({ expiresAt })])
+    expect(screen.getByText(/expires in 3 days/)).toBeInTheDocument()
+  })
+
+  it('does not show an expiry badge for a URL with no expiry or a far-off one', () => {
+    renderTable([makeUrl({ expiresAt: null })])
+    expect(screen.queryByText('expired')).not.toBeInTheDocument()
+    expect(screen.queryByText(/expires in/)).not.toBeInTheDocument()
+  })
+
+  it('deletes a single URL after confirming, shows a toast, and refreshes', async () => {
+    const user = userEvent.setup()
+    mockDeleteUrl.mockResolvedValue(undefined)
+    renderTable([makeUrl({ slug: 'abc123' })])
+
+    await user.click(screen.getByRole('button', { name: 'Delete /abc123' }))
+    expect(screen.getByText('Delete /abc123?')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Delete' }))
+
+    await waitFor(() => expect(mockDeleteUrl).toHaveBeenCalledWith('abc123'))
+    expect(await screen.findByText('URL removed')).toBeInTheDocument()
+    expect(mockRefresh).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows an error toast when a single delete fails', async () => {
+    const user = userEvent.setup()
+    mockDeleteUrl.mockRejectedValue(new Error('boom'))
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    renderTable([makeUrl({ slug: 'abc123' })])
+
+    await user.click(screen.getByRole('button', { name: 'Delete /abc123' }))
+    await user.click(screen.getByRole('button', { name: 'Delete' }))
+
+    expect(await screen.findByText('An error occurred when deleting the URL.')).toBeInTheDocument()
+    expect(mockRefresh).not.toHaveBeenCalled()
+  })
+
+  it('supports selecting URLs and bulk-deleting them', async () => {
+    const user = userEvent.setup()
+    mockDeleteUrls.mockResolvedValue({ deleted: 2 })
+    renderTable([makeUrl({ id: '1', slug: 'foo' }), makeUrl({ id: '2', slug: 'bar' })])
+
+    await user.click(screen.getByRole('checkbox', { name: 'Select /foo' }))
+    await user.click(screen.getByRole('checkbox', { name: 'Select /bar' }))
+
+    expect(screen.getByText('2 selected')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /delete 2/i }))
+    const dialog = screen.getByRole('alertdialog')
+    expect(within(dialog).getByText('Delete 2 URLs?')).toBeInTheDocument()
+
+    await user.click(within(dialog).getByRole('button', { name: 'Delete 2' }))
+
+    await waitFor(() =>
+      expect(mockDeleteUrls).toHaveBeenCalledWith(expect.arrayContaining(['foo', 'bar'])),
+    )
+    expect(await screen.findByText('2 URLs deleted')).toBeInTheDocument()
+    expect(mockRefresh).toHaveBeenCalledTimes(1)
+  })
+
+  it('clears the selection via the Clear button', async () => {
+    const user = userEvent.setup()
+    renderTable([makeUrl({ id: '1', slug: 'foo' })])
+
+    await user.click(screen.getByRole('checkbox', { name: 'Select /foo' }))
+    expect(screen.getByText('1 selected')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Clear' }))
+    expect(screen.queryByText('1 selected')).not.toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/UrlsView/UrlsView.test.tsx
+++ b/apps/web/src/components/UrlsView/UrlsView.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/react'
+import { ThemeProvider } from 'styled-components'
+import { describe, expect, it, vi } from 'vitest'
+import type { UrlList } from '@snip/types'
+import { theme } from '@/lib/theme'
+import { ToastProvider } from '@/components/Toast'
+import { UrlsView } from './UrlsView'
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+}))
+
+vi.mock('@/lib/api', () => ({
+  api: { deleteUrl: vi.fn(), deleteUrls: vi.fn() },
+}))
+
+function makeList(overrides: Partial<UrlList> = {}): UrlList {
+  return {
+    data: [],
+    meta: { total: 0, page: 1, perPage: 10, totalPages: 0 },
+    ...overrides,
+  }
+}
+
+function renderUrlsView(props: React.ComponentProps<typeof UrlsView>) {
+  return render(
+    <ThemeProvider theme={theme}>
+      <ToastProvider>
+        <UrlsView {...props} />
+      </ToastProvider>
+    </ThemeProvider>,
+  )
+}
+
+describe('UrlsView', () => {
+  it('renders the table and pagination when there is data', () => {
+    const data = makeList({
+      data: [
+        {
+          id: '1',
+          slug: 'abc123',
+          originalUrl: 'https://example.com',
+          shortUrl: 'http://localhost:3001/abc123',
+          customSlug: false,
+          title: null,
+          description: null,
+          expiresAt: null,
+          createdAt: '2024-01-01T00:00:00.000Z',
+        },
+      ],
+      meta: { total: 1, page: 1, perPage: 10, totalPages: 1 },
+    })
+    renderUrlsView({ data })
+
+    expect(screen.getByText('https://example.com')).toBeInTheDocument()
+    expect(screen.getByText('1–1 of 1 URLs')).toBeInTheDocument()
+  })
+
+  it('shows a generic empty message when there is no query', () => {
+    renderUrlsView({ data: makeList() })
+    expect(screen.getByText('No results')).toBeInTheDocument()
+  })
+
+  it('shows a query-specific empty message when searching with no matches', () => {
+    renderUrlsView({ data: makeList(), q: 'nothing-matches' })
+    expect(screen.getByText('No results for "nothing-matches"')).toBeInTheDocument()
+  })
+
+  it('treats an out-of-range page as an empty result', () => {
+    const data = makeList({ meta: { total: 5, page: 3, perPage: 10, totalPages: 1 } })
+    renderUrlsView({ data })
+    expect(screen.getByText('No results')).toBeInTheDocument()
+  })
+
+  it('renders the search input with the current query', () => {
+    renderUrlsView({ data: makeList(), q: 'foo' })
+    expect(screen.getByLabelText('Search URLs')).toHaveValue('foo')
+  })
+})

--- a/apps/web/src/components/ui/ConfirmDialog.test.tsx
+++ b/apps/web/src/components/ui/ConfirmDialog.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ThemeProvider } from 'styled-components'
+import { describe, expect, it, vi } from 'vitest'
+import { theme } from '@/lib/theme'
+import { ConfirmDialog } from './ConfirmDialog'
+
+function renderDialog(overrides: Partial<React.ComponentProps<typeof ConfirmDialog>> = {}) {
+  const onConfirm = vi.fn()
+  const onCancel = vi.fn()
+  render(
+    <ThemeProvider theme={theme}>
+      <ConfirmDialog
+        title="Delete /abc123?"
+        message="This cannot be undone."
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+        {...overrides}
+      />
+    </ThemeProvider>,
+  )
+  return { onConfirm, onCancel }
+}
+
+describe('ConfirmDialog', () => {
+  it('renders the title and message', () => {
+    renderDialog()
+    expect(screen.getByText('Delete /abc123?')).toBeInTheDocument()
+    expect(screen.getByText('This cannot be undone.')).toBeInTheDocument()
+  })
+
+  it('renders default Cancel/Confirm buttons and calls the right handler for each', async () => {
+    const user = userEvent.setup()
+    const { onConfirm, onCancel } = renderDialog()
+
+    await user.click(screen.getByRole('button', { name: 'Confirm' }))
+    expect(onConfirm).toHaveBeenCalledTimes(1)
+    expect(onCancel).not.toHaveBeenCalled()
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses a custom confirmLabel when provided', () => {
+    renderDialog({ confirmLabel: 'Delete 3' })
+    expect(screen.getByRole('button', { name: 'Delete 3' })).toBeInTheDocument()
+  })
+
+  it('renders custom actions instead of the default buttons', () => {
+    renderDialog({ actions: <button>Custom action</button> })
+    expect(screen.getByRole('button', { name: 'Custom action' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Confirm' })).not.toBeInTheDocument()
+  })
+
+  it('calls onCancel when clicking the overlay but not when clicking inside the dialog', async () => {
+    const user = userEvent.setup()
+    const { onCancel } = renderDialog()
+
+    await user.click(screen.getByText('Delete /abc123?'))
+    expect(onCancel).not.toHaveBeenCalled()
+
+    await user.click(screen.getByRole('alertdialog').parentElement!)
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onCancel when Escape is pressed', async () => {
+    const user = userEvent.setup()
+    const { onCancel } = renderDialog()
+
+    await user.keyboard('{Escape}')
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('focuses the cancel button on mount', () => {
+    renderDialog()
+    expect(screen.getByRole('button', { name: 'Cancel' })).toHaveFocus()
+  })
+})


### PR DESCRIPTION
## Summary
Closes the four zero-coverage components called out in #170.

- **ConfirmDialog** — title/message rendering, default vs custom `actions`, confirm/cancel handlers, overlay-click-to-cancel (vs clicking inside the dialog), Escape key, focus-on-mount
- **Pagination** — result-range text, Prev/Next disabled at page boundaries, href construction including search-query passthrough
- **Table** — row rendering, expired/expiring-soon badges, single-delete flow (confirm → API call → toast → `router.refresh()`), error toast on a failed delete, and the full bulk flow: select → bulk bar → bulk delete → confirm → API call → toast → selection cleared
- **UrlsView** — renders `Table`+`Pagination` when there's data, and the three empty-state paths: no query, query with no matches, and an out-of-range page

Follows the existing `ShortenForm.test.tsx` conventions: full render (not shallow) wrapped in `ThemeProvider` + `ToastProvider`, `@/lib/api` mocked, `next/navigation`'s `useRouter` mocked for the two components that call it.

## Testing
- `pnpm --filter web run test` — 66/66 passing (26 new)
- `pnpm --filter web run typecheck` ✅
- `pnpm --filter web run lint` ✅

Closes #170