### PR TITLE
feat: add PATCH /urls/:slug endpoint for editing URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ An interactive API reference (powered by [Scalar](https://scalar.com)) is availa
 | `GET`    | `/urls`             | Yes           | List short URLs (paginated)       |
 | `GET`    | `/urls/:slug/stats` | Yes           | Click statistics for a slug       |
 | `GET`    | `/preview/:slug`    | Yes           | URL metadata without redirecting  |
+| `PATCH`  | `/urls/:slug`       | Yes           | Update title, description, expiry |
 | `DELETE` | `/urls/:slug`       | Yes           | Delete a short URL                |
 | `DELETE` | `/urls`             | Yes           | Bulk delete short URLs            |
 | `GET`    | `/:slug`            | No            | Redirect to original URL          |
@@ -290,6 +291,18 @@ An interactive API reference (powered by [Scalar](https://scalar.com)) is availa
 | `400`  | Invalid body or URL points to this service or resolves to a private address |
 | `409`  | `customSlug` is already taken                                               |
 | `422`  | URL hostname could not be resolved via DNS                                  |
+
+### PATCH /urls/:slug
+
+```json
+{
+  "title": "New title",
+  "description": null,
+  "expiresAt": "2027-01-01T00:00:00.000Z"
+}
+```
+
+All fields are optional — omit a field to leave it unchanged, or send it as `null` to clear it. At least one field must be provided. Returns `200` with the updated record, `400` for an empty or invalid body, or `404` if the slug doesn't exist.
 
 ### GET /:slug
 

--- a/apps/api/src/routes/urls.test.ts
+++ b/apps/api/src/routes/urls.test.ts
@@ -22,6 +22,7 @@ vi.mock('../services/url.service.js', async () => {
     deleteUrl: vi.fn(),
     deleteUrls: vi.fn(),
     getUrlPreview: vi.fn(),
+    updateUrl: vi.fn(),
   }
 })
 
@@ -39,6 +40,7 @@ import {
   deleteUrls,
   getUrlList,
   getUrlPreview,
+  updateUrl,
   UrlFetchError,
 } from '../services/url.service.js'
 import { parsePagination } from '../lib/pagination.js'
@@ -404,6 +406,65 @@ describe('DELETE /urls', () => {
   })
 })
 
+describe('PATCH /urls/:slug', () => {
+  it('returns 200 with the updated record', async () => {
+    vi.mocked(updateUrl).mockResolvedValue({ ...mockUrlRecord, title: 'New title' })
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/urls/abc12345',
+      payload: { title: 'New title' },
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.json().title).toBe('New title')
+    expect(updateUrl).toHaveBeenCalledWith('abc12345', { title: 'New title' })
+  })
+
+  it('passes an explicit null through as clearing the field', async () => {
+    vi.mocked(updateUrl).mockResolvedValue({ ...mockUrlRecord, description: null })
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/urls/abc12345',
+      payload: { description: null },
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(updateUrl).toHaveBeenCalledWith('abc12345', { description: null })
+  })
+
+  it('returns 400 for an empty body', async () => {
+    const res = await app.inject({ method: 'PATCH', url: '/urls/abc12345', payload: {} })
+
+    expect(res.statusCode).toBe(400)
+    expect(updateUrl).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 for a title over the length limit', async () => {
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/urls/abc12345',
+      payload: { title: 'a'.repeat(201) },
+    })
+
+    expect(res.statusCode).toBe(400)
+  })
+
+  it('returns 404 when the URL does not exist', async () => {
+    vi.mocked(updateUrl).mockResolvedValue(null)
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/urls/notexist',
+      payload: { title: 'New title' },
+    })
+
+    expect(res.statusCode).toBe(404)
+    expect(res.json().error).toBe('URL not found')
+  })
+})
+
 describe('GET /preview/:slug', () => {
   it('returns 200 with preview', async () => {
     vi.mocked(getUrlPreview).mockResolvedValue(mockUrlRecord)
@@ -565,6 +626,32 @@ describe('API_KEY enforcement', () => {
         method: 'DELETE',
         url: '/urls',
         payload: { slugs: ['abc12345'] },
+        headers: { authorization: 'Bearer test-api-key' },
+      })
+
+      expect(res.statusCode).toBe(200)
+    })
+  })
+
+  describe('PATCH /urls/:slug', () => {
+    it('returns 401 when API_KEY is set and no Authorization header is provided', async () => {
+      const res = await app.inject({
+        method: 'PATCH',
+        url: '/urls/abc12345',
+        payload: { title: 'New title' },
+      })
+
+      expect(res.statusCode).toBe(401)
+      expect(res.json().error).toBe('Unauthorized')
+    })
+
+    it('returns 200 when API_KEY is set and correct Authorization header is provided', async () => {
+      vi.mocked(updateUrl).mockResolvedValue(mockUrlRecord)
+
+      const res = await app.inject({
+        method: 'PATCH',
+        url: '/urls/abc12345',
+        payload: { title: 'New title' },
         headers: { authorization: 'Bearer test-api-key' },
       })
 

--- a/apps/api/src/routes/urls.ts
+++ b/apps/api/src/routes/urls.ts
@@ -1,5 +1,5 @@
 import type { FastifyInstance } from 'fastify'
-import { CreateUrlInputSchema, BulkDeleteUrlsInputSchema } from '@snip/types'
+import { CreateUrlInputSchema, BulkDeleteUrlsInputSchema, UpdateUrlInputSchema } from '@snip/types'
 import {
   createUrl,
   getUrlStats,
@@ -7,6 +7,7 @@ import {
   deleteUrls,
   getUrlList,
   getUrlPreview,
+  updateUrl,
   UrlFetchError,
 } from '../services/url.service.js'
 import { env } from '../config.js'
@@ -288,6 +289,89 @@ export async function urlRoutes(fastify: FastifyInstance) {
         return reply.status(404).send({ error: 'URL not found' })
       }
       return reply.status(204).send()
+    },
+  )
+
+  // PATCH /urls/:slug
+  fastify.patch<{ Params: { slug: string } }>(
+    '/urls/:slug',
+    {
+      preHandler: [requireApiKey],
+      schema: {
+        tags: ['URLs'],
+        summary: 'Update a short URL',
+        description:
+          'Partially updates title, description, and/or expiry. Omit a field to leave it unchanged, or send it as null to clear it.',
+        security: routeSecurity,
+        params: {
+          type: 'object',
+          properties: { slug: { type: 'string', description: 'Short URL slug' } },
+        },
+        body: {
+          type: 'object',
+          properties: {
+            title: {
+              type: 'string',
+              maxLength: 200,
+              nullable: true,
+              description: 'New title, or null to clear it',
+            },
+            description: {
+              type: 'string',
+              maxLength: 500,
+              nullable: true,
+              description: 'New description, or null to clear it',
+            },
+            expiresAt: {
+              type: 'string',
+              format: 'date-time',
+              nullable: true,
+              description: 'New expiry timestamp in ISO 8601 format, or null to remove expiry',
+            },
+          },
+        },
+        response: {
+          200: {
+            description: 'URL updated',
+            type: 'object',
+            properties: {
+              id: { type: 'string' },
+              slug: { type: 'string' },
+              originalUrl: { type: 'string' },
+              customSlug: { type: 'boolean' },
+              title: { type: 'string', nullable: true },
+              description: { type: 'string', nullable: true },
+              expiresAt: { type: 'string', format: 'date-time', nullable: true },
+              createdAt: { type: 'string', format: 'date-time' },
+            },
+          },
+          400: {
+            description: 'Validation error',
+            type: 'object',
+            properties: { error: { type: 'string' }, message: { type: 'string' } },
+          },
+          404: {
+            description: 'URL not found',
+            type: 'object',
+            properties: { error: { type: 'string' } },
+          },
+        },
+      },
+    },
+    async (request, reply) => {
+      const parsed = UpdateUrlInputSchema.safeParse(request.body)
+      if (!parsed.success) {
+        return reply.status(400).send({
+          error: 'Validation error',
+          message: parsed.error.issues.map((i) => i.message).join(', '),
+        })
+      }
+
+      const updated = await updateUrl(request.params.slug, parsed.data)
+      if (!updated) {
+        return reply.status(404).send({ error: 'URL not found' })
+      }
+      return reply.send(updated)
     },
   )
 

--- a/apps/api/src/services/url.service.test.ts
+++ b/apps/api/src/services/url.service.test.ts
@@ -8,6 +8,8 @@ const {
   mockInsertValues,
   mockSelectChain,
   mockDeleteReturning,
+  mockUpdateReturning,
+  mockUpdateSet,
   mockFetch,
 } = vi.hoisted(() => {
   function makeSelectChain(result: unknown) {
@@ -29,6 +31,9 @@ const {
   const mockInsertReturning = vi.fn()
   const mockInsertValues = vi.fn(() => ({ returning: mockInsertReturning }))
 
+  const mockUpdateReturning = vi.fn()
+  const mockUpdateSet = vi.fn(() => ({ where: () => ({ returning: mockUpdateReturning }) }))
+
   return {
     makeSelectChain,
     mockFindFirstUrl: vi.fn(),
@@ -37,6 +42,8 @@ const {
     mockInsertValues,
     mockSelectChain: vi.fn(() => makeSelectChain([])),
     mockDeleteReturning: vi.fn(),
+    mockUpdateReturning,
+    mockUpdateSet,
     mockFetch,
   }
 })
@@ -50,6 +57,7 @@ vi.mock('../db/client.js', () => ({
     insert: () => ({ values: mockInsertValues }),
     select: mockSelectChain,
     delete: () => ({ where: () => ({ returning: mockDeleteReturning }) }),
+    update: () => ({ set: mockUpdateSet }),
   },
 }))
 
@@ -72,6 +80,7 @@ import {
   deleteUrls,
   getUrlList,
   getUrlPreview,
+  updateUrl,
 } from './url.service.js'
 import dns from 'node:dns/promises'
 import ipaddr from 'ipaddr.js'
@@ -455,6 +464,43 @@ describe('getUrlStats', () => {
       { domain: 'google.com', count: 3 },
       { domain: 'Direct', count: 2 },
     ])
+  })
+})
+
+describe('updateUrl', () => {
+  it('updates only the provided fields', async () => {
+    mockUpdateReturning.mockResolvedValue([{ ...mockUrlRow, title: 'New title' }])
+
+    const result = await updateUrl('abc12345', { title: 'New title' })
+
+    expect(mockUpdateSet).toHaveBeenCalledWith({ title: 'New title' })
+    expect(result?.title).toBe('New title')
+  })
+
+  it('clears a field when it is explicitly set to null', async () => {
+    mockUpdateReturning.mockResolvedValue([{ ...mockUrlRow, description: null }])
+
+    await updateUrl('abc12345', { description: null })
+
+    expect(mockUpdateSet).toHaveBeenCalledWith({ description: null })
+  })
+
+  it('converts expiresAt to a Date, or null when cleared', async () => {
+    mockUpdateReturning.mockResolvedValue([mockUrlRow])
+
+    await updateUrl('abc12345', { expiresAt: '2025-01-01T00:00:00.000Z' })
+    expect(mockUpdateSet).toHaveBeenCalledWith({ expiresAt: new Date('2025-01-01T00:00:00.000Z') })
+
+    await updateUrl('abc12345', { expiresAt: null })
+    expect(mockUpdateSet).toHaveBeenCalledWith({ expiresAt: null })
+  })
+
+  it('returns null when the slug does not exist', async () => {
+    mockUpdateReturning.mockResolvedValue([])
+
+    const result = await updateUrl('notexist', { title: 'New title' })
+
+    expect(result).toBeNull()
   })
 })
 

--- a/apps/api/src/services/url.service.ts
+++ b/apps/api/src/services/url.service.ts
@@ -7,6 +7,7 @@ import { urls, clicks, type Url, type Click } from '../db/schema.js'
 import type {
   CreateUrlInput,
   CreateUrlResponse,
+  UpdateUrlInput,
   UrlStats,
   ClickRecord,
   UrlRecord,
@@ -194,6 +195,16 @@ export async function findUrlBySlug(slug: string): Promise<Url | null> {
     where: eq(urls.slug, slug),
   })
   return url ?? null
+}
+
+export async function updateUrl(slug: string, input: UpdateUrlInput): Promise<UrlRecord | null> {
+  const values: Partial<Pick<Url, 'title' | 'description' | 'expiresAt'>> = {}
+  if ('title' in input) values.title = input.title ?? null
+  if ('description' in input) values.description = input.description ?? null
+  if ('expiresAt' in input) values.expiresAt = input.expiresAt ? new Date(input.expiresAt) : null
+
+  const [url] = await db.update(urls).set(values).where(eq(urls.slug, slug)).returning()
+  return url ? toUrlRecord(url) : null
 }
 
 export async function recordClick(

--- a/apps/web/src/app/api/proxy/urls/[slug]/route.test.ts
+++ b/apps/web/src/app/api/proxy/urls/[slug]/route.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
 
 afterEach(() => {
   vi.unstubAllGlobals()
@@ -86,5 +87,72 @@ describe('DELETE /api/proxy/urls/[slug] — without API_KEY', () => {
       RequestInit & { headers: Record<string, string> },
     ]
     expect(init.headers['Authorization']).toBeUndefined()
+  })
+})
+
+function makePatchRequest(body: unknown, extraHeaders: Record<string, string> = {}) {
+  return new NextRequest('http://localhost/api/proxy/urls/abc', {
+    method: 'PATCH',
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json', ...extraHeaders },
+  })
+}
+
+describe('PATCH /api/proxy/urls/[slug]', () => {
+  let PATCH: (req: NextRequest, ctx: { params: Promise<{ slug: string }> }) => Promise<Response>
+
+  beforeAll(async () => {
+    process.env['API_URL'] = 'http://localhost:3001'
+    process.env['API_KEY'] = 'test-key'
+    vi.resetModules()
+    const mod = await import('./route')
+    PATCH = mod.PATCH
+  })
+
+  it('forwards the body to the API with an Authorization header', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      status: 200,
+      json: async () => ({ slug: 'abc', title: 'New title' }),
+    })
+    vi.stubGlobal('fetch', mockFetch)
+
+    const res = await PATCH(makePatchRequest({ title: 'New title' }), {
+      params: Promise.resolve({ slug: 'abc' }),
+    })
+
+    expect(res.status).toBe(200)
+    const [url, init] = mockFetch.mock.calls[0] as [
+      string,
+      RequestInit & { headers: Record<string, string>; body: string },
+    ]
+    expect(url).toBe('http://localhost:3001/urls/abc')
+    expect(init.method).toBe('PATCH')
+    expect(init.headers['Authorization']).toBe('Bearer test-key')
+    expect(init.body).toBe(JSON.stringify({ title: 'New title' }))
+  })
+
+  it('passes through API error status and body', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ status: 404, json: async () => ({ error: 'URL not found' }) }),
+    )
+
+    const res = await PATCH(makePatchRequest({ title: 'New title' }), {
+      params: Promise.resolve({ slug: 'unknown' }),
+    })
+
+    expect(res.status).toBe(404)
+    const body = await res.json()
+    expect(body.error).toBe('URL not found')
+  })
+
+  it('returns 413 when Content-Length exceeds 1 MB', async () => {
+    const res = await PATCH(makePatchRequest({ title: 'x' }, { 'Content-Length': '1048577' }), {
+      params: Promise.resolve({ slug: 'abc' }),
+    })
+
+    expect(res.status).toBe(413)
+    const body = await res.json()
+    expect(body.error).toBe('Request body too large')
   })
 })

--- a/apps/web/src/app/api/proxy/urls/[slug]/route.ts
+++ b/apps/web/src/app/api/proxy/urls/[slug]/route.ts
@@ -1,8 +1,16 @@
 import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
 
 const API_URL =
   process.env['API_URL'] ?? process.env['NEXT_PUBLIC_API_URL'] ?? 'http://localhost:3001'
 const API_KEY = process.env['API_KEY']
+
+const MAX_BODY_BYTES = 1_048_576 // 1 MB — matches Fastify's default bodyLimit
+
+function isBodyTooLarge(request: NextRequest): boolean {
+  const contentLength = request.headers.get('content-length')
+  return contentLength !== null && parseInt(contentLength, 10) > MAX_BODY_BYTES
+}
 
 export async function DELETE(_request: Request, { params }: { params: Promise<{ slug: string }> }) {
   const { slug } = await params
@@ -11,6 +19,24 @@ export async function DELETE(_request: Request, { params }: { params: Promise<{ 
 
   const res = await fetch(`${API_URL}/urls/${slug}`, { method: 'DELETE', headers })
   if (res.status === 204) return new NextResponse(null, { status: 204 })
+  const data = await res.json()
+  return NextResponse.json(data, { status: res.status })
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string }> },
+) {
+  if (isBodyTooLarge(request)) {
+    return NextResponse.json({ error: 'Request body too large' }, { status: 413 })
+  }
+
+  const { slug } = await params
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+  if (API_KEY) headers['Authorization'] = `Bearer ${API_KEY}`
+
+  const body = await request.text()
+  const res = await fetch(`${API_URL}/urls/${slug}`, { method: 'PATCH', headers, body })
   const data = await res.json()
   return NextResponse.json(data, { status: res.status })
 }

--- a/apps/web/src/components/StatsView.test.tsx
+++ b/apps/web/src/components/StatsView.test.tsx
@@ -1,0 +1,154 @@
+// @vitest-environment jsdom
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ThemeProvider } from 'styled-components'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import type { UrlStats } from '@snip/types'
+import { theme } from '@/lib/theme'
+import { ToastProvider } from '@/components/Toast'
+import { StatsView } from './StatsView'
+
+const mockRefresh = vi.fn()
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ refresh: mockRefresh, replace: vi.fn() }),
+}))
+
+vi.mock('@/lib/api', () => {
+  class ApiError extends Error {
+    constructor(
+      public readonly status: number,
+      message: string,
+    ) {
+      super(message)
+      this.name = 'ApiError'
+    }
+  }
+  return {
+    api: { deleteUrl: vi.fn(), updateUrl: vi.fn() },
+    ApiError,
+  }
+})
+
+import { api } from '@/lib/api'
+
+const mockUpdateUrl = vi.mocked(api.updateUrl)
+
+const mockStats: UrlStats = {
+  url: {
+    id: 'uuid-1',
+    slug: 'abc123',
+    originalUrl: 'https://example.com',
+    customSlug: false,
+    title: 'Original title',
+    description: 'Original description',
+    expiresAt: null,
+    createdAt: '2024-01-01T00:00:00.000Z',
+    shortUrl: 'http://localhost:3001/abc123',
+  },
+  totalClicks: 0,
+  clicksByDay: [],
+  clicksLast24h: 0,
+  clicksLast7d: 0,
+  recentClicks: [],
+  referrers: [],
+}
+
+function renderStatsView() {
+  return render(
+    <ThemeProvider theme={theme}>
+      <ToastProvider>
+        <StatsView stats={mockStats} slug="abc123" />
+      </ToastProvider>
+    </ThemeProvider>,
+  )
+}
+
+beforeEach(() => {
+  mockRefresh.mockClear()
+  mockUpdateUrl.mockReset()
+})
+
+describe('StatsView — edit', () => {
+  it('does not show the edit form until Edit is clicked', () => {
+    renderStatsView()
+    expect(screen.queryByLabelText('Title')).not.toBeInTheDocument()
+  })
+
+  it('opens the edit form pre-filled with the current title and description', async () => {
+    const user = userEvent.setup()
+    renderStatsView()
+
+    await user.click(screen.getByRole('button', { name: 'Edit' }))
+
+    expect(screen.getByLabelText('Title')).toHaveValue('Original title')
+    expect(screen.getByLabelText('Description')).toHaveValue('Original description')
+  })
+
+  it('saves the edited fields and refreshes on success', async () => {
+    const user = userEvent.setup()
+    mockUpdateUrl.mockResolvedValue({ ...mockStats.url, title: 'New title' })
+    renderStatsView()
+
+    await user.click(screen.getByRole('button', { name: 'Edit' }))
+    await user.clear(screen.getByLabelText('Title'))
+    await user.type(screen.getByLabelText('Title'), 'New title')
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() =>
+      expect(mockUpdateUrl).toHaveBeenCalledWith('abc123', {
+        title: 'New title',
+        description: 'Original description',
+        expiresAt: null,
+      }),
+    )
+    expect(await screen.findByText('URL updated')).toBeInTheDocument()
+    expect(mockRefresh).toHaveBeenCalledTimes(1)
+    expect(screen.queryByLabelText('Title')).not.toBeInTheDocument()
+  })
+
+  it('clears a field by submitting it empty', async () => {
+    const user = userEvent.setup()
+    mockUpdateUrl.mockResolvedValue({ ...mockStats.url, description: null })
+    renderStatsView()
+
+    await user.click(screen.getByRole('button', { name: 'Edit' }))
+    await user.clear(screen.getByLabelText('Description'))
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() =>
+      expect(mockUpdateUrl).toHaveBeenCalledWith(
+        'abc123',
+        expect.objectContaining({ description: null }),
+      ),
+    )
+  })
+
+  it('shows an error toast and keeps the form open when saving fails', async () => {
+    const user = userEvent.setup()
+    mockUpdateUrl.mockRejectedValue(new Error('network error'))
+    renderStatsView()
+
+    await user.click(screen.getByRole('button', { name: 'Edit' }))
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(await screen.findByText('Failed to update the URL.')).toBeInTheDocument()
+    expect(screen.getByLabelText('Title')).toBeInTheDocument()
+    expect(mockRefresh).not.toHaveBeenCalled()
+  })
+
+  it('discards changes when Cancel is clicked', async () => {
+    const user = userEvent.setup()
+    renderStatsView()
+
+    await user.click(screen.getByRole('button', { name: 'Edit' }))
+    await user.clear(screen.getByLabelText('Title'))
+    await user.type(screen.getByLabelText('Title'), 'Unsaved change')
+    await user.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    expect(screen.queryByLabelText('Title')).not.toBeInTheDocument()
+    expect(mockUpdateUrl).not.toHaveBeenCalled()
+
+    await user.click(screen.getByRole('button', { name: 'Edit' }))
+    expect(screen.getByLabelText('Title')).toHaveValue('Original title')
+  })
+})

--- a/apps/web/src/components/StatsView.tsx
+++ b/apps/web/src/components/StatsView.tsx
@@ -1,9 +1,10 @@
 'use client'
 
+import { useState } from 'react'
 import styled from 'styled-components'
 import type { UrlStats } from '@snip/types'
 import { Button, useConfirmDialog } from './ui'
-import { api } from '@/lib/api'
+import { api, ApiError } from '@/lib/api'
 import { useRouter } from 'next/navigation'
 import { useToast } from './Toast'
 import { QRCodeSVG } from 'qrcode.react'
@@ -215,7 +216,74 @@ const ExpiredBanner = styled.div`
   margin-bottom: 0.75rem;
 `
 
+const EditField = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+  margin-bottom: 1rem;
+
+  &:last-of-type {
+    margin-bottom: 0;
+  }
+`
+
+const EditLabel = styled.label`
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: ${({ theme }) => theme.colors.textSecondary};
+`
+
+const EditInput = styled.input`
+  width: 100%;
+  border: 1px solid ${({ theme }) => theme.colors.inputBorder};
+  border-radius: 0.375rem;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.875rem;
+  outline: none;
+  background: ${({ theme }) => theme.colors.surface};
+  color: ${({ theme }) => theme.colors.textPrimary};
+`
+
+const EditTextarea = styled.textarea`
+  width: 100%;
+  border: 1px solid ${({ theme }) => theme.colors.inputBorder};
+  border-radius: 0.375rem;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.875rem;
+  outline: none;
+  background: ${({ theme }) => theme.colors.surface};
+  color: ${({ theme }) => theme.colors.textPrimary};
+  font-family: inherit;
+  resize: vertical;
+`
+
+const EditActions = styled.div`
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 1.25rem;
+`
+
+const CancelEditButton = styled.button`
+  background: ${({ theme }) => theme.colors.surfaceHover};
+  color: ${({ theme }) => theme.colors.textPrimary};
+  border: 1px solid ${({ theme }) => theme.colors.border};
+  border-radius: 0.375rem;
+  padding: 0.625rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+`
+
 // ---- Component ----
+
+// datetime-local inputs want "YYYY-MM-DDTHH:mm" in local time, no timezone suffix —
+// shift by the local offset so the displayed wall-clock time round-trips correctly
+// through `new Date(value).toISOString()` (which parses the un-suffixed string as local).
+function toDatetimeLocal(iso: string | null): string {
+  if (!iso) return ''
+  const d = new Date(iso)
+  return new Date(d.getTime() - d.getTimezoneOffset() * 60_000).toISOString().slice(0, 16)
+}
 
 interface Props {
   stats: UrlStats
@@ -228,6 +296,12 @@ export function StatsView({ stats, slug }: Props) {
   const { openConfirmDialog, confirmDialog } = useConfirmDialog()
   const { url, totalClicks, clicksLast24h, clicksLast7d } = stats
   const maxClicks = Math.max(totalClicks, 1)
+
+  const [isEditing, setIsEditing] = useState(false)
+  const [editTitle, setEditTitle] = useState(url.title ?? '')
+  const [editDescription, setEditDescription] = useState(url.description ?? '')
+  const [editExpiresAt, setEditExpiresAt] = useState(toDatetimeLocal(url.expiresAt))
+  const [saving, setSaving] = useState(false)
 
   function pct(v: number) {
     return Math.round((v / maxClicks) * 100)
@@ -251,6 +325,32 @@ export function StatsView({ stats, slug }: Props) {
     })
   }
 
+  function startEditing() {
+    setEditTitle(url.title ?? '')
+    setEditDescription(url.description ?? '')
+    setEditExpiresAt(toDatetimeLocal(url.expiresAt))
+    setIsEditing(true)
+  }
+
+  async function handleSave(e: React.FormEvent) {
+    e.preventDefault()
+    setSaving(true)
+    try {
+      await api.updateUrl(slug, {
+        title: editTitle || null,
+        description: editDescription || null,
+        expiresAt: editExpiresAt ? new Date(editExpiresAt).toISOString() : null,
+      })
+      showToast('URL updated', 'success')
+      setIsEditing(false)
+      router.refresh()
+    } catch (err) {
+      showToast(err instanceof ApiError ? err.message : 'Failed to update the URL.', 'error')
+    } finally {
+      setSaving(false)
+    }
+  }
+
   const isExpired = url.expiresAt ? new Date(url.expiresAt) < new Date() : false
   const expiresAtFormatted = url.expiresAt
     ? new Date(url.expiresAt).toLocaleDateString('en-US', { dateStyle: 'long' })
@@ -263,6 +363,9 @@ export function StatsView({ stats, slug }: Props) {
         <PageTitle>
           Stats for <span>/{slug}</span>
         </PageTitle>
+        <Button type="button" onClick={startEditing}>
+          Edit
+        </Button>
         <Button color="error" onClick={handleDelete}>
           Delete
         </Button>
@@ -279,6 +382,49 @@ export function StatsView({ stats, slug }: Props) {
         <ExpiredBanner>
           This URL expired on {expiresAtFormatted} and now returns 410 Gone.
         </ExpiredBanner>
+      )}
+
+      {isEditing && (
+        <Card as="form" onSubmit={handleSave}>
+          <CardLabel style={{ marginBottom: '0.75rem' }}>Edit URL</CardLabel>
+          <EditField>
+            <EditLabel htmlFor="edit-title">Title</EditLabel>
+            <EditInput
+              id="edit-title"
+              type="text"
+              maxLength={200}
+              value={editTitle}
+              onChange={(e) => setEditTitle(e.target.value)}
+            />
+          </EditField>
+          <EditField>
+            <EditLabel htmlFor="edit-description">Description</EditLabel>
+            <EditTextarea
+              id="edit-description"
+              rows={3}
+              maxLength={500}
+              value={editDescription}
+              onChange={(e) => setEditDescription(e.target.value)}
+            />
+          </EditField>
+          <EditField>
+            <EditLabel htmlFor="edit-expires">Expires at</EditLabel>
+            <EditInput
+              id="edit-expires"
+              type="datetime-local"
+              value={editExpiresAt}
+              onChange={(e) => setEditExpiresAt(e.target.value)}
+            />
+          </EditField>
+          <EditActions>
+            <Button type="submit" disabled={saving}>
+              {saving ? 'Saving…' : 'Save'}
+            </Button>
+            <CancelEditButton type="button" onClick={() => setIsEditing(false)}>
+              Cancel
+            </CancelEditButton>
+          </EditActions>
+        </Card>
       )}
 
       <DetailsGrid>

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,7 +1,9 @@
 import type {
   CreateUrlInput,
   CreateUrlResponse,
+  UpdateUrlInput,
   UrlList,
+  UrlRecord,
   UrlStats,
   BulkDeleteUrlsResponse,
 } from '@snip/types'
@@ -80,6 +82,12 @@ export const api = {
     }),
 
   getStats: (slug: string): Promise<UrlStats> => apiFetch(`/urls/${slug}/stats`),
+
+  updateUrl: (slug: string, input: UpdateUrlInput): Promise<UrlRecord> =>
+    proxyFetch(`/api/proxy/urls/${slug}`, {
+      method: 'PATCH',
+      body: JSON.stringify(input),
+    }),
 
   deleteUrl: (slug: string): Promise<void> =>
     proxyFetch(`/api/proxy/urls/${slug}`, { method: 'DELETE' }),

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -16,9 +16,11 @@ import type {
   UrlListRecordSchema,
   BulkDeleteUrlsInputSchema,
   BulkDeleteUrlsResponseSchema,
+  UpdateUrlInputSchema,
 } from './schemas.js'
 
 export type CreateUrlInput = z.infer<typeof CreateUrlInputSchema>
+export type UpdateUrlInput = z.infer<typeof UpdateUrlInputSchema>
 export type CreateUrlResponse = z.infer<typeof CreateUrlResponseSchema>
 export type UrlRecord = z.infer<typeof UrlRecordSchema>
 export type ClickRecord = z.infer<typeof ClickRecordSchema>

--- a/packages/types/src/schemas.ts
+++ b/packages/types/src/schemas.ts
@@ -29,6 +29,16 @@ export const SlugParamSchema = z.object({
   slug: z.string().min(1),
 })
 
+export const UpdateUrlInputSchema = z
+  .object({
+    title: z.string().max(200).nullable().optional(),
+    description: z.string().max(500).nullable().optional(),
+    expiresAt: z.iso.datetime().nullable().optional(),
+  })
+  .refine((data) => Object.keys(data).length > 0, {
+    message: 'At least one field (title, description, expiresAt) must be provided',
+  })
+
 // ---- Response schemas ----
 
 export const UrlRecordSchema = z.object({


### PR DESCRIPTION
## Summary
URLs were immutable after creation — no way to fix a typo'd title/description or adjust expiry without deleting and recreating. Adds a partial-update endpoint plus an Edit form on the stats page.

- **`UpdateUrlInputSchema`** (`packages/types`): `title`/`description`/`expiresAt`, all optional and nullable. Omit a field to leave it unchanged; send `null` to explicitly clear it. Refined to require at least one field so an empty PATCH is rejected.
- **`updateUrl` service**: builds the Drizzle `.set()` payload only from keys actually present in the parsed input (`'title' in input`), so an omitted field is never touched — as opposed to always including all three and risking silently nulling out fields the client didn't mean to touch.
- **`PATCH /urls/:slug` route**: auth + Zod validation, `404` when the slug doesn't exist, full OpenAPI schema.
- **Next.js proxy `PATCH` handler**: mirrors the existing `DELETE` handler's auth/body-size-limit pattern, added to `apps/web/src/lib/api.ts` as `api.updateUrl()`.
- **StatsView**: an "Edit" button reveals a form (title, description, expiry via native `<input type="datetime-local">`) that saves through the new endpoint and refreshes the page. Kept it inline on the stats page rather than a separate modal/route — smallest addition that covers the ask.

## Testing
- `apps/api`: service tests for partial updates, explicit-null clearing, expiresAt conversion, not-found; route tests for success, validation, 404, and API-key enforcement
- `apps/web`: proxy-route tests (forwarding, error passthrough, body-size limit) and a `StatsView.test.tsx` covering the new edit flow (pre-fill, save, clear-via-empty, error handling, cancel)
- `pnpm --filter api run test` — 225/225 passing
- `pnpm --filter web run test` — 81/81 passing
- `npx tsc -b --noEmit` (full monorepo) ✅
- `pnpm --filter api run lint` / `pnpm --filter web run lint` / `pnpm --filter @snip/types run lint` ✅
- README endpoint table + `PATCH /urls/:slug` docs section updated

Closes #157