### PR TITLE
test: add Playwright E2E tests for the core happy path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,3 +117,66 @@ jobs:
         env:
           # Needed for Next.js build — dummy value is fine for a build-only check
           NEXT_PUBLIC_API_URL: http://localhost:3001
+
+  e2e:
+    name: E2E tests
+    runs-on: ubuntu-latest
+    needs: [build]
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: snip
+          POSTGRES_PASSWORD: snip
+          POSTGRES_DB: snip
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U snip"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DATABASE_URL: postgresql://snip:snip@localhost:5432/snip
+      IP_HASH_SECRET: e2e-test-secret
+      NEXT_PUBLIC_API_URL: http://localhost:3001
+      CI: true
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Cache Turbo
+        uses: actions/cache@v6
+        with:
+          path: .turbo
+          key: turbo-${{ github.sha }}
+          restore-keys: turbo-
+
+      - name: Build
+        run: pnpm build
+
+      - name: Run migrations
+        run: pnpm --filter api run migrate
+
+      - name: Install Playwright browsers
+        run: pnpm --filter e2e exec playwright install --with-deps chromium
+
+      - name: Run E2E tests
+        run: pnpm test:e2e
+
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: apps/e2e/playwright-report/
+          retention-days: 7

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ The `DATABASE_URL` defaults to the local `db` service (`postgresql://snip:snip@d
 | `pnpm test:api --watch`                  | Run API tests in watch mode                  |
 | `pnpm test:web`                          | Run web unit tests (no server required)      |
 | `pnpm test:web --watch`                  | Run web tests in watch mode                  |
+| `pnpm test:e2e`                          | Run Playwright E2E tests (see `apps/e2e`)    |
 | `pnpm --filter api run migrate:generate` | Generate migration files from schema changes |
 
 ## Environment variables

--- a/apps/e2e/.gitignore
+++ b/apps/e2e/.gitignore
@@ -1,0 +1,4 @@
+test-results/
+playwright-report/
+blob-report/
+playwright/.cache/

--- a/apps/e2e/README.md
+++ b/apps/e2e/README.md
@@ -1,0 +1,37 @@
+# E2E tests
+
+Playwright tests that drive the real app end to end: the built API and web servers, a real
+Postgres database, a real browser. No mocks.
+
+## Running locally
+
+1. Start Postgres and apply migrations (once):
+
+   ```bash
+   docker compose up -d db
+   DATABASE_URL=postgresql://snip:snip@localhost:5432/snip pnpm --filter api run migrate
+   ```
+
+2. Build the app (Playwright starts the built servers, not `dev`):
+
+   ```bash
+   NEXT_PUBLIC_API_URL=http://localhost:3001 pnpm build
+   ```
+
+3. Install browsers (once):
+
+   ```bash
+   pnpm --filter e2e exec playwright install chromium
+   ```
+
+4. Run the tests:
+
+   ```bash
+   DATABASE_URL=postgresql://snip:snip@localhost:5432/snip pnpm test:e2e
+   ```
+
+`playwright.config.ts`'s `webServer` entries start `apps/api` and `apps/web` automatically
+(`reuseExistingServer` when not in CI, so a `pnpm dev` already running on 3000/3001 is reused
+instead of relaunched). `IP_HASH_SECRET` defaults to a test value if unset.
+
+Use `pnpm --filter e2e run test:ui` for Playwright's interactive UI mode while iterating on a test.

--- a/apps/e2e/package.json
+++ b/apps/e2e/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "e2e",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "playwright test",
+    "test:ui": "playwright test --ui",
+    "lint": "eslint .",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.56.1",
+    "@snip/tsconfig": "workspace:*",
+    "@types/node": "^22.20.1",
+    "typescript": "^5.7.2"
+  }
+}

--- a/apps/e2e/playwright.config.ts
+++ b/apps/e2e/playwright.config.ts
@@ -1,0 +1,57 @@
+import { defineConfig, devices } from '@playwright/test'
+
+const WEB_PORT = 3000
+const API_PORT = 3001
+const WEB_URL = `http://localhost:${WEB_PORT}`
+const API_URL = `http://localhost:${API_PORT}`
+
+// Starting real servers (not mocks) — these tests exercise the actual API, DB, and
+// SSR pages end to end. Requires a reachable Postgres at DATABASE_URL with migrations
+// already applied; see apps/e2e/README.md.
+export default defineConfig({
+  testDir: './tests',
+  // Default 30s is tight once you add cold webServer startup on top of the test's own
+  // steps — bump it so a slower CI runner doesn't flake on timing alone.
+  timeout: 60_000,
+  fullyParallel: true,
+  forbidOnly: !!process.env['CI'],
+  retries: process.env['CI'] ? 2 : 0,
+  workers: process.env['CI'] ? 1 : undefined,
+  reporter: process.env['CI'] ? [['html', { open: 'never' }], ['github']] : 'list',
+  use: {
+    baseURL: WEB_URL,
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: [
+    {
+      command: 'pnpm --filter api run start',
+      url: `${API_URL}/health`,
+      reuseExistingServer: !process.env['CI'],
+      timeout: 30_000,
+      env: {
+        PORT: String(API_PORT),
+        BASE_URL: API_URL,
+        CORS_ORIGIN: WEB_URL,
+        DATABASE_URL: process.env['DATABASE_URL'] ?? 'postgresql://snip:snip@localhost:5432/snip',
+        IP_HASH_SECRET: process.env['IP_HASH_SECRET'] ?? 'e2e-test-secret',
+      },
+    },
+    {
+      command: 'pnpm --filter web run start',
+      url: WEB_URL,
+      reuseExistingServer: !process.env['CI'],
+      timeout: 30_000,
+      env: {
+        PORT: String(WEB_PORT),
+        NEXT_PUBLIC_API_URL: API_URL,
+        API_URL,
+      },
+    },
+  ],
+})

--- a/apps/e2e/tests/core-flow.spec.ts
+++ b/apps/e2e/tests/core-flow.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect } from '@playwright/test'
+
+// The redirect lives on the API, not the Next.js app — apps/e2e/playwright.config.ts
+// points page.baseURL at the web app, so this needs the API's own origin.
+const API_URL = process.env['E2E_API_URL'] ?? 'http://localhost:3001'
+
+function uniqueSlug() {
+  return `e2e-${Date.now()}-${Math.floor(Math.random() * 10_000)}`
+}
+
+test('create, redirect, track a click, and delete a URL', async ({ page }) => {
+  const slug = uniqueSlug()
+  const targetUrl = 'https://example.com/'
+
+  await test.step('create a short URL with a custom slug', async () => {
+    await page.goto('/new')
+    await page.getByLabel('URL to shorten').fill(targetUrl)
+    await page.getByLabel(/custom slug/i).fill(slug)
+    await page.getByRole('button', { name: 'Shorten URL' }).click()
+
+    await expect(page.getByText('Your short URL is ready!')).toBeVisible()
+    await expect(page.getByRole('link', { name: new RegExp(slug) })).toBeVisible()
+  })
+
+  await test.step('appears in the URLs list', async () => {
+    await page.goto(`/urls?q=${slug}`)
+    await expect(page.getByText(targetUrl)).toBeVisible()
+  })
+
+  await test.step('visiting the short URL redirects to the original URL', async () => {
+    await page.goto(`${API_URL}/${slug}`)
+    await page.waitForURL(/example\.com/)
+  })
+
+  await test.step('the click shows up on the stats page', async () => {
+    await page.goto(`/stats/${slug}`)
+    // Click recording is fire-and-forget on the API side, so poll instead of a flat wait.
+    await expect(async () => {
+      await page.reload()
+      await expect(page.getByTestId('total-clicks')).toHaveText('1')
+    }).toPass({ timeout: 10_000 })
+  })
+
+  await test.step('deleting the URL removes it from the list', async () => {
+    await page.getByRole('button', { name: 'Delete' }).click()
+    const dialog = page.getByRole('alertdialog')
+    await expect(dialog).toBeVisible()
+    await dialog.getByRole('button', { name: 'Delete' }).click()
+
+    await page.waitForURL('**/urls')
+    await page.goto(`/urls?q=${slug}`)
+    await expect(page.getByText('No results')).toBeVisible()
+  })
+})

--- a/apps/e2e/tsconfig.json
+++ b/apps/e2e/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "@snip/tsconfig/node.json",
+  "compilerOptions": {
+    "types": ["node"]
+  },
+  "include": ["playwright.config.ts", "tests"]
+}

--- a/apps/web/src/components/StatsView.tsx
+++ b/apps/web/src/components/StatsView.tsx
@@ -299,7 +299,7 @@ export function StatsView({ stats, slug }: Props) {
 
       <StatsGrid>
         <StatCard>
-          <StatValue>{totalClicks.toLocaleString('en-US')}</StatValue>
+          <StatValue data-testid="total-clicks">{totalClicks.toLocaleString('en-US')}</StatValue>
           <StatLabel>Total clicks</StatLabel>
         </StatCard>
         <StatCard>

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "format:check": "prettier --check .",
     "test:api": "pnpm --filter api run test",
     "test:web": "pnpm --filter web run test",
+    "test:e2e": "pnpm --filter e2e run test",
     "prepare": "husky"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,6 +127,21 @@ importers:
         specifier: ^4.1.10
         version: 4.1.10(@types/node@22.20.1)(@vitest/coverage-v8@4.1.10)(jsdom@26.1.0(supports-color@7.2.0))(vite@8.2.0(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.5)(yaml@2.9.0))
 
+  apps/e2e:
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.56.1
+        version: 1.62.1
+      '@snip/tsconfig':
+        specifier: workspace:*
+        version: link:../../packages/tsconfig
+      '@types/node':
+        specifier: ^22.20.1
+        version: 22.20.1
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+
   apps/web:
     dependencies:
       '@snip/types':
@@ -134,7 +149,7 @@ importers:
         version: link:../../packages/types
       next:
         specifier: ^16.2.12
-        version: 16.2.12(@babel/core@7.29.7(supports-color@7.2.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 16.2.12(@babel/core@7.29.7(supports-color@7.2.0))(@playwright/test@1.62.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       qrcode.react:
         specifier: ^4.2.0
         version: 4.2.0(react@19.2.8)
@@ -1214,6 +1229,11 @@ packages:
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
 
+  '@playwright/test@1.62.1':
+    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
+    engines: {node: '>=20'}
+    hasBin: true
+
   '@rolldown/binding-android-arm64@1.2.1':
     resolution: {integrity: sha512-02hOeOSryYxVrOIphmLAsqnCJWxwlzFk+pEt/N/i6OgT3lShHO7xGCU5cpgchRDHboAEbSjzgGh+O/u1GswQmA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2285,6 +2305,11 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -3028,6 +3053,16 @@ packages:
 
   pino@10.3.1:
     resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
+    hasBin: true
+
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
     hasBin: true
 
   possible-typed-array-names@1.1.0:
@@ -4497,6 +4532,10 @@ snapshots:
 
   '@pinojs/redact@0.4.0': {}
 
+  '@playwright/test@1.62.1':
+    dependencies:
+      playwright: 1.62.1
+
   '@rolldown/binding-android-arm64@1.2.1':
     optional: true
 
@@ -5694,6 +5733,9 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -6237,7 +6279,7 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next@16.2.12(@babel/core@7.29.7(supports-color@7.2.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+  next@16.2.12(@babel/core@7.29.7(supports-color@7.2.0))(@playwright/test@1.62.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       '@next/env': 16.2.12
       '@swc/helpers': 0.5.15
@@ -6256,6 +6298,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.2.12
       '@next/swc-win32-arm64-msvc': 16.2.12
       '@next/swc-win32-x64-msvc': 16.2.12
+      '@playwright/test': 1.62.1
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -6454,6 +6497,14 @@ snapshots:
       safe-stable-stringify: 2.5.0
       sonic-boom: 4.2.1
       thread-stream: 4.2.0
+
+  playwright-core@1.62.1: {}
+
+  playwright@1.62.1:
+    dependencies:
+      playwright-core: 1.62.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 


### PR DESCRIPTION
## Summary
No end-to-end coverage existed. Adds a Playwright suite covering the flow from the issue:

1. Create a short URL → verify it appears in the list
2. Visit the short URL → verify it redirects to the original
3. Open the stats page → verify the click was recorded
4. Delete the URL → verify it disappears from the list

## Structure
- **New workspace package `apps/e2e`** (picked up automatically by `pnpm-workspace.yaml`'s existing `apps/*` glob — no workspace config changes needed).
- **`playwright.config.ts`** starts the real API and web servers via their built `start` scripts (not `dev` — this exercises what actually ships) against a real Postgres. `reuseExistingServer` outside CI, so a `pnpm dev` already running on 3000/3001 gets reused instead of relaunched.
- Two things about the app's actual behavior the test had to account for:
  - The redirect route serves a client-side meta-refresh + `location.replace(...)` page rather than an HTTP 3xx (existing, deliberate — it's how the OG meta tags work for link previews on shares), so the test waits for the resulting browser navigation instead of asserting a redirect status.
  - Click recording is fire-and-forget (`setImmediate`) on the API side, so the stats assertion polls (`toPass` with reload) instead of a single page load.
- Added one `data-testid` to `StatsView.tsx` — the simplest stable selector for a number that's otherwise only distinguishable by DOM position among three near-identical stat cards.
- **CI**: new `e2e` job — Postgres service container, build, migrate, install browsers, run, upload the HTML report as an artifact (`if: !cancelled()`, so it still uploads on a test failure, not just success). Runs after the existing `build` job.
- README: `pnpm test:e2e` in the scripts table; `apps/e2e/README.md` has full local setup steps.

## Testing
This one I actually ran for real rather than just typecheck/lint, since a Playwright config that only looks right on paper is worse than useless:
- Started Postgres via `docker compose up -d db`, ran migrations, built all packages, installed the Chromium browser, and ran `pnpm test:e2e` end to end against the real stack — **passing**.
- Also verified it passes both via Playwright's own `webServer` auto-start *and* against manually-started servers (`reuseExistingServer` path).
- Bumped the default test timeout to 60s after seeing the default 30s be too tight once cold `webServer` startup is added on top of the test's own steps — first attempt timed out on that alone, not a real bug.
- `pnpm exec turbo lint` / `pnpm exec turbo typecheck` — both include the new `e2e` package now, clean.
- `pnpm format:check` — clean.
- Full `apps/api` (214/214) and `apps/web` (72/72) unit suites still pass — the only production-code change is the one `data-testid`.

Closes #171